### PR TITLE
Add autocompletion for fish shell

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -23,7 +23,7 @@ export abstract class AutocompleteBase extends Command {
       this.error('Missing required argument shell')
     }
     this.errorIfWindows()
-    if (!['bash', 'zsh'].includes(shell)) {
+    if (!['bash', 'fish', 'zsh'].includes(shell)) {
       throw new Error(`${shell} is not a supported shell for autocomplete`)
     }
   }

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -31,8 +31,6 @@ export default class Create extends AutocompleteBase {
     await fs.ensureDir(this.autocompleteCacheDir)
     // ensure autocomplete bash function dir
     await fs.ensureDir(this.bashFunctionsDir)
-    // ensure autocomplete fish function dir
-    await fs.ensureDir(this.fishFunctionsDir)
     // ensure autocomplete zsh function dir
     await fs.ensureDir(this.zshFunctionsDir)
   }
@@ -58,11 +56,6 @@ export default class Create extends AutocompleteBase {
   private get bashFunctionsDir(): string {
     // <cachedir>/autocomplete/functions/bash
     return path.join(this.autocompleteCacheDir, 'functions', 'bash')
-  }
-
-  private get fishFunctionsDir(): string {
-    // <cachedir>/autocomplete/functions/fish
-    return path.join(this.autocompleteCacheDir, 'functions', 'fish')
   }
 
   private get zshFunctionsDir(): string {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -1,3 +1,4 @@
+import * as child_process from 'child_process'
 import * as fs from 'fs-extra'
 import * as path from 'path'
 
@@ -39,20 +40,14 @@ export default class Create extends AutocompleteBase {
   private async createFiles() {
     await fs.writeFile(this.bashSetupScriptPath, this.bashSetupScript)
     await fs.writeFile(this.bashCompletionFunctionPath, this.bashCompletionFunction)
-    await fs.writeFile(this.fishSetupScriptPath, this.fishSetupScript)
-    await fs.writeFile(this.fishCompletionFunctionPath, this.fishCompletionFunction)
     await fs.writeFile(this.zshSetupScriptPath, this.zshSetupScript)
     await fs.writeFile(this.zshCompletionFunctionPath, this.zshCompletionFunction)
+    await fs.writeFile(this.fishCompletionFunctionPath, this.fishCompletionFunction)
   }
 
   private get bashSetupScriptPath(): string {
     // <cachedir>/autocomplete/bash_setup
     return path.join(this.autocompleteCacheDir, 'bash_setup')
-  }
-
-  private get fishSetupScriptPath(): string {
-    // <cachedir>/autocomplete/fish_setup
-    return path.join(this.autocompleteCacheDir, 'fish_setup')
   }
 
   private get zshSetupScriptPath(): string {
@@ -81,8 +76,9 @@ export default class Create extends AutocompleteBase {
   }
 
   private get fishCompletionFunctionPath(): string {
-    // <cachedir>/autocomplete/functions/fish/<bin>.fish
-    return path.join(this.fishFunctionsDir, `${this.cliBin}.fish`)
+    // dynamically load path to completions file
+    const dir = child_process.execSync('pkg-config --variable completionsdir fish').toString().trimRight()
+    return `${dir}/${this.cliBin}.fish`
   }
 
   private get zshCompletionFunctionPath(): string {
@@ -95,10 +91,6 @@ export default class Create extends AutocompleteBase {
     const bin = this.cliBinEnvVar
     return `${bin}_AC_BASH_COMPFUNC_PATH=${setup} && test -f \$${bin}_AC_BASH_COMPFUNC_PATH && source \$${bin}_AC_BASH_COMPFUNC_PATH;
 `
-  }
-
-  private get fishSetupScript(): string {
-    return 'TODO: Fill this in'
   }
 
   private get zshSetupScript(): string {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -30,6 +30,8 @@ export default class Create extends AutocompleteBase {
     await fs.ensureDir(this.autocompleteCacheDir)
     // ensure autocomplete bash function dir
     await fs.ensureDir(this.bashFunctionsDir)
+    // ensure autocomplete fish function dir
+    await fs.ensureDir(this.fishFunctionsDir)
     // ensure autocomplete zsh function dir
     await fs.ensureDir(this.zshFunctionsDir)
   }
@@ -37,6 +39,8 @@ export default class Create extends AutocompleteBase {
   private async createFiles() {
     await fs.writeFile(this.bashSetupScriptPath, this.bashSetupScript)
     await fs.writeFile(this.bashCompletionFunctionPath, this.bashCompletionFunction)
+    await fs.writeFile(this.fishSetupScriptPath, this.fishSetupScript)
+    await fs.writeFile(this.fishCompletionFunctionPath, this.fishCompletionFunction)
     await fs.writeFile(this.zshSetupScriptPath, this.zshSetupScript)
     await fs.writeFile(this.zshCompletionFunctionPath, this.zshCompletionFunction)
   }
@@ -44,6 +48,11 @@ export default class Create extends AutocompleteBase {
   private get bashSetupScriptPath(): string {
     // <cachedir>/autocomplete/bash_setup
     return path.join(this.autocompleteCacheDir, 'bash_setup')
+  }
+
+  private get fishSetupScriptPath(): string {
+    // <cachedir>/autocomplete/fish_setup
+    return path.join(this.autocompleteCacheDir, 'fish_setup')
   }
 
   private get zshSetupScriptPath(): string {
@@ -56,6 +65,11 @@ export default class Create extends AutocompleteBase {
     return path.join(this.autocompleteCacheDir, 'functions', 'bash')
   }
 
+  private get fishFunctionsDir(): string {
+    // <cachedir>/autocomplete/functions/fish
+    return path.join(this.autocompleteCacheDir, 'functions', 'fish')
+  }
+
   private get zshFunctionsDir(): string {
     // <cachedir>/autocomplete/functions/zsh
     return path.join(this.autocompleteCacheDir, 'functions', 'zsh')
@@ -64,6 +78,11 @@ export default class Create extends AutocompleteBase {
   private get bashCompletionFunctionPath(): string {
     // <cachedir>/autocomplete/functions/bash/<bin>.bash
     return path.join(this.bashFunctionsDir, `${this.cliBin}.bash`)
+  }
+
+  private get fishCompletionFunctionPath(): string {
+    // <cachedir>/autocomplete/functions/fish/<bin>.fish
+    return path.join(this.fishFunctionsDir, `${this.cliBin}.fish`)
   }
 
   private get zshCompletionFunctionPath(): string {
@@ -76,6 +95,10 @@ export default class Create extends AutocompleteBase {
     const bin = this.cliBinEnvVar
     return `${bin}_AC_BASH_COMPFUNC_PATH=${setup} && test -f \$${bin}_AC_BASH_COMPFUNC_PATH && source \$${bin}_AC_BASH_COMPFUNC_PATH;
 `
+  }
+
+  private get fishSetupScript(): string {
+    return 'TODO: Fill this in'
   }
 
   private get zshSetupScript(): string {
@@ -220,6 +243,10 @@ ${this.bashCommandsWithFlagsList}
 
 complete -F _${cliBin} ${cliBin}
 `
+    }
+
+    private get fishCompletionFunction(): string {
+      return 'complete -xc fish -s h -l help -d \"Show usage help\"'
     }
 
     private get zshCompletionFunction(): string {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -40,7 +40,10 @@ export default class Create extends AutocompleteBase {
     await fs.writeFile(this.bashCompletionFunctionPath, this.bashCompletionFunction)
     await fs.writeFile(this.zshSetupScriptPath, this.zshSetupScript)
     await fs.writeFile(this.zshCompletionFunctionPath, this.zshCompletionFunction)
-    await fs.writeFile(this.fishCompletionFunctionPath, this.fishCompletionFunction)
+    if (this.config.shell === "fish") {
+      debug(`fish shell detected, writing completion to ${this.fishCompletionFunctionPath}`);
+      await fs.writeFile(this.fishCompletionFunctionPath, this.fishCompletionFunction)
+    }
   }
 
   private get bashSetupScriptPath(): string {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -238,7 +238,43 @@ complete -F _${cliBin} ${cliBin}
     }
 
     private get fishCompletionFunction(): string {
-      return 'complete -xc fish -s h -l help -d \"Show usage help\"'
+      const cliBin = this.cliBin
+      const completions = []
+      completions.push(`
+function __fish_${cliBin}_needs_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 ]
+    return 0
+  else
+    return 1
+  end
+end
+
+function  __fish_${cliBin}_using_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -gt 1 ]
+    if [ $argv[1] = $cmd[2] ]
+      return 0
+    end
+  end
+  return 1
+end`
+      )
+
+      for (const command of this.commands) {
+        completions.push(`complete -f -c ${cliBin} -n '__fish_${cliBin}_needs_command' -a ${command.id} -d "${command.description}"`)
+        const flags = command.flags || {}
+        Object.keys(flags)
+        .filter(flag => flags[flag] && !flags[flag].hidden)
+        .forEach(flag => {
+          const f = flags[flag] || {}
+          const shortFlag = f.char ? `-s ${f.char}` : ''
+          const description = f.description ? `-d "${f.description}"` : ''
+          const options = f.options ? `-r -a "${f.options.join(' ')}"` : ''
+          completions.push(`complete -f -c ${cliBin} -n ' __fish_${cliBin}_using_command ${command.id}' -l ${flag} ${shortFlag} ${options} ${description}`)
+        })
+      }
+      return completions.join('\n')
     }
 
     private get zshCompletionFunction(): string {

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -34,8 +34,8 @@ export default class Index extends AutocompleteBase {
 
     if (!flags['refresh-cache']) {
       const bin = this.config.bin
-      let tabStr = shell === 'bash' ? '<TAB><TAB>' : '<TAB>'
-      let note = shell === 'zsh' ? `After sourcing, you can run \`${chalk.cyan('$ compaudit -D')}\` to ensure no permissions conflicts are present` : 'If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.'
+      const tabStr = this.getTabStr(shell)
+      const note = this.getNote(shell)
 
       this.log(`
 ${chalk.bold(`Setup Instructions for ${bin.toUpperCase()} CLI Autocomplete ---`)}
@@ -51,6 +51,31 @@ ${chalk.cyan(`$ ${bin} command --${tabStr}`)}       # Flag completion
 
 Enjoy!
 `)
+    }
+  }
+
+  private getNote(shell: string): string {
+    switch (shell) {
+      case 'bash':
+        return 'If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.'
+      case 'fish':
+        return 'TODO: Fill this in'
+      case 'zsh':
+        return `After sourcing, you can run \`${chalk.cyan('$ compaudit -D')}\` to ensure no permissions conflicts are present`
+      default:
+        return ''
+    }
+  }
+
+  private getTabStr(shell: string): string {
+    switch (shell) {
+      case 'bash':
+        return '<TAB><TAB>'
+      case 'fish':
+      case 'zsh':
+        return '<TAB>'
+      default:
+        return ''
     }
   }
 }

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -73,7 +73,7 @@ ${chalk.cyan('source ~/.config/fish/config.fish')}`
       case 'bash':
         return 'If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.'
       case 'fish':
-        return 'This assumes your Fish shell is configuration is stored at ~/.config/fish'
+        return 'This assumes your Fish configuration is stored at ~/.config/fish/config.fish'
       case 'zsh':
         return `After sourcing, you can run \`${chalk.cyan('$ compaudit -D')}\` to ensure no permissions conflicts are present`
       default:

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -18,6 +18,7 @@ export default class Index extends AutocompleteBase {
   static examples = [
     '$ <%= config.bin %> autocomplete',
     '$ <%= config.bin %> autocomplete bash',
+    '$ <%= config.bin %> autocomplete fish',
     '$ <%= config.bin %> autocomplete zsh',
     '$ <%= config.bin %> autocomplete --refresh-cache'
   ]

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -35,13 +35,13 @@ export default class Index extends AutocompleteBase {
     if (!flags['refresh-cache']) {
       const bin = this.config.bin
       const tabStr = this.getTabStr(shell)
+      const setupStep = this.getSetupStep(shell, bin)
       const note = this.getNote(shell)
 
       this.log(`
 ${chalk.bold(`Setup Instructions for ${bin.toUpperCase()} CLI Autocomplete ---`)}
 
-1) Add the autocomplete env var to your ${shell} profile and source it
-${chalk.cyan(`$ printf "$(${bin} autocomplete:script ${shell})" >> ~/.${shell}rc; source ~/.${shell}rc`)}
+1) ${setupStep}
 
 NOTE: ${note}
 
@@ -54,12 +54,26 @@ Enjoy!
     }
   }
 
+  private getSetupStep(shell: string, bin: string): string {
+    switch (shell) {
+      case 'bash':
+      case 'zsh':
+        return `Add the autocomplete env var to your ${shell} profile and source it
+${chalk.cyan(`$ printf "$(${bin} autocomplete:script ${shell})" >> ~/.${shell}rc; source ~/.${shell}rc`)}`
+      case 'fish':
+        return `Update your shell to load the new completions
+${chalk.cyan('source ~/.config/fish/config.fish')}`
+      default:
+        return ''
+    }
+  }
+
   private getNote(shell: string): string {
     switch (shell) {
       case 'bash':
         return 'If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.'
       case 'fish':
-        return 'TODO: Fill this in'
+        return 'This assumes your Fish shell is configuration is stored at ~/.config/fish'
       case 'zsh':
         return `After sourcing, you can run \`${chalk.cyan('$ compaudit -D')}\` to ensure no permissions conflicts are present`
       default:


### PR DESCRIPTION
Fixes #3 
Adds support for [`fish`](https://fishshell.com/) using their [guide for writing custom completions](https://fishshell.com/docs/current/#completion-own)

I've managed to get this working smoothly on my machine using a Oclif tool and would love a couple of other testers.

# Recording
[![asciicast](https://asciinema.org/a/USqHX7VcQo9XT5l8WtnGnPGbx.svg)](https://asciinema.org/a/USqHX7VcQo9XT5l8WtnGnPGbx)

# Details
Automatically detects the correct path to store fish completion files in using `pkg-config` to detect the "completionsdir" variable. This comes from the advice on that page:
> If you are developing another program and would like to ship completions with your program, install them to the "vendor" completions directory. As this path may vary from system to system, the pkgconfig framework should be used to discover this path with the output of pkg-config --variable completionsdir fish.

This will operate slightly different than how `bash` and `zsh` operate. Since those shells require you to add lines to you `.bashrc` or `.zshrc` in order to source the functions file, they necessitated a "setup" file as well as a manual addition to the configs. `fish` on the other hand will automatically detect completions by name in the completions folder, and so does not require a setup script, or manual intervention by the user. We'll simply write the completions to the appropriate directory.

Since we're now dealing with three shells instead of two, I've refactored some of the `index.ts` module to rely on some private methods with switch/case statements instead of the ternary used previously.
