### PR TITLE
Only use the first line of the command description for zsh

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -132,7 +132,7 @@ compinit;\n`
 
     private get genAllCommandsMetaString(): string {
       return this.commands.map(c => {
-        return `\"${c.id.replace(/:/g, '\\:')}:${c.description}\"`
+        return `\"${c.id.replace(/:/g, '\\:')}:${c.description.split('\n')[0]}\"`
       }).join('\n')
     }
 

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -30,7 +30,7 @@
     },
     "autocomplete:foo": {
       "id": "autocomplete:foo",
-      "description": "cmd for autocomplete testing",
+      "description": "cmd for autocomplete testing\nwith a multi-line description",
       "pluginName": "@oclif/plugin-autocomplete",
       "pluginType": "core",
       "aliases": [],


### PR DESCRIPTION
Resolves the following sample autocomplete output:
```
api:v2010:accounts:fetch                                                           -- Fetch the account specified by the provided Account Sid
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:create                  -- [BETA] Assign an Add-on installation to the Number specified.
 
PLEASE NOTE that this is a Beta product that is s
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:extensions:fetch        -- [BETA] Fetch an instance of an Extension for the Assigned Add-on.
 
PLEASE NOTE that this is a Beta product that 
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:extensions:list         -- [BETA] Retrieve a list of Extensions for the Assigned Add-on.
 
PLEASE NOTE that this is a Beta product that is s
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:fetch                   -- [BETA] Fetch an instance of an Add-on installation currently assigned to this Number.
 
PLEASE NOTE that this is 
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:list                    -- [BETA] Retrieve a list of Add-on installations currently assigned to this Number.
 
PLEASE NOTE that this is a Be
api:v2010:accounts:incoming-phone-numbers:assigned-add-ons:remove                  -- [BETA] Remove the assignment of an Add-on installation from the Number specified.
 
PLEASE NOTE that this is a Be
```