### PR TITLE
Add Zsh autocompletion for the argument options if there are any.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@oclif/command": "^1.4.31",
     "@oclif/config": "^1.6.22",
+    "@oclif/parser": "^3.8.0",
     "@types/fs-extra": "^5.0.2",
     "chalk": "^2.4.1",
     "cli-ux": "^4.4.0",

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -137,13 +137,14 @@ compinit;\n`
 
     const commandArguments = (Klass.args || [])
       .map(argOptions => {
-         if (argOptions.hidden) {
+        const optionalPrefix = argOptions.required ? '' : ':'
+        if (argOptions.hidden) {
            // Order matters for arguments, so we want to keep the hidden ones
            // to preserve the ordering, but hide the options.
-           return '":hidden argument:"'
-         }
-         const autocompleteOptions = argOptions.options ? `(${argOptions.options.sort().join(' ')})` : ''
-         return `":${argOptions.description}:${autocompleteOptions}"`
+           return `"${optionalPrefix}:hidden argument:"`
+        }
+        const autocompleteOptions = argOptions.options ? `(${argOptions.options.sort().join(' ')})` : ''
+        return `"${optionalPrefix}:${argOptions.description}:${autocompleteOptions}"`
       })
 
     return flags.concat(commandArguments).join('\n')
@@ -162,6 +163,7 @@ compinit;\n`
       //     "--value=-[value descr]:"
       //     ":argument description:(option-1 option-2 option-3)"
       //     ":argument without options description:"
+      //     "::optional argument without options description:"
       //     ":hidden argument:"
       //   )
       // ;;

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -121,7 +121,7 @@ complete -F _oclif-example oclif-example\n`)
 _oclif-example () {
   local _command_id=\${words[2]}
   local _cur=\${words[CURRENT]}
-  local -a _command_flags=()
+  local -a _command_flags_and_args=()
 
   ## public cli commands & flags
   local -a _all_commands=(
@@ -129,16 +129,17 @@ _oclif-example () {
 "autocomplete\\:foo:cmd for autocomplete testing"
   )
 
-  _set_flags () {
+  _set_flags_and_arguments () {
     case $_command_id in
 autocomplete)
-  _command_flags=(
+  _command_flags_and_args=(
     "--skip-instructions[don't show installation instructions]"
+":shell type:(bash zsh)"
   )
 ;;
 
 autocomplete:foo)
-  _command_flags=(
+  _command_flags_and_args=(
     "--bar=-[bar for testing]:"
 "--baz=-[baz for testing]:"
 "--json[output in json format]"
@@ -154,14 +155,12 @@ autocomplete:foo)
   }
 
   if [ $CURRENT -gt 2 ]; then
-    if [[ "$_cur" == -* ]]; then
-      _set_flags
-    fi
+    _set_flags_and_arguments
   fi
 
 
   _arguments -S '1: :_complete_commands' \\
-                $_command_flags
+                $_command_flags_and_args
 }
 
 _oclif-example\n`)

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -134,7 +134,7 @@ _oclif-example () {
 autocomplete)
   _command_flags_and_args=(
     "--skip-instructions[don't show installation instructions]"
-":shell type:(bash zsh)"
+"::shell type:(bash zsh)"
   )
 ;;
 

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -24,7 +24,8 @@
         {
           "name": "shell",
           "description": "shell type",
-          "required": false
+          "required": false,
+          "options": ["zsh", "bash"]
         }
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,15 @@
     "@oclif/linewrap" "^1.0.0"
     chalk "^2.4.1"
 
+"@oclif/parser@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.0.tgz#397c73f92cf8ac82daa7448a916638a312775e3b"
+  integrity sha512-w1fCz0bpg1ukbYKLxQn3cYQS9hiqNgmFhlqAqqfr1k0ijMhA/g8Z+7mshiFs1w7OsxxnKhmRxPn7EZR4EJcemA==
+  dependencies:
+    "@oclif/linewrap" "^1.0.0"
+    chalk "^2.4.2"
+    tslib "^1.9.3"
+
 "@oclif/plugin-help@^2.0.1", "@oclif/plugin-help@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-2.0.4.tgz#32cf1dc7696f626a6065109a17b0f061adb14243"
@@ -443,6 +452,15 @@ chalk@^1.1.3:
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -2209,6 +2227,11 @@ tslib@1.9.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
 tslib@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
+
+tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tslint-consistent-codestyle@^1.11.0:
   version "1.13.0"


### PR DESCRIPTION
Options are shown alphabetically and only for the argument that is next to be entered. Flags can be freely interspersed with the arguments without affecting their ordering.

I'm not sure if this level of detail can be achieved with bash, so I've not tried yet.

Fixes https://github.com/oclif/plugin-autocomplete/issues/1 (for Zsh)