### PR TITLE
fix: backtick in description of commands/flags sanitized

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -100,7 +100,7 @@ compinit;\n`
           if (c.hidden) return
           cmds.push({
             id: c.id,
-            description: c.description || '',
+            description: (c.description || '').replace(/`/g, '\''),
             flags: c.flags
           })
         } catch (err) {
@@ -124,7 +124,7 @@ compinit;\n`
         const isBoolean = f.type === 'boolean'
         const name = isBoolean ? flag : `${flag}=-`
         let valueCmpl = isBoolean ? '' : ':'
-        const completion = `--${name}[${f.description}]${valueCmpl}`
+        const completion = `--${name}[${f.description.replace(/`/g, '\'')}]${valueCmpl}`
         return `"${completion}"`
       })
       .join('\n')

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -11,7 +11,10 @@ type CommandCompletion = {
   flags: any
 }
 
-function sanitizeDescription(description: string): string {
+function sanitizeDescription(description?: string): string {
+  if (description === undefined) {
+    return ''
+  }
   return description.replace(/`/g, '\\\\\\\`')
 }
 

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -11,6 +11,10 @@ type CommandCompletion = {
   flags: any
 }
 
+function sanitizeDescription(description: string): string {
+  return description.replace(/`/g, '\\\\\\\`')
+}
+
 export default class Create extends AutocompleteBase {
   static hidden = true
   static description = 'create autocomplete setup scripts and completion functions'
@@ -100,7 +104,7 @@ compinit;\n`
           if (c.hidden) return
           cmds.push({
             id: c.id,
-            description: (c.description || '').replace(/`/g, '\''),
+            description: sanitizeDescription(c.description || ''),
             flags: c.flags
           })
         } catch (err) {
@@ -124,7 +128,7 @@ compinit;\n`
         const isBoolean = f.type === 'boolean'
         const name = isBoolean ? flag : `${flag}=-`
         let valueCmpl = isBoolean ? '' : ':'
-        const completion = `--${name}[${f.description.replace(/`/g, '\'')}]${valueCmpl}`
+        const completion = `--${name}[${sanitizeDescription(f.description)}]${valueCmpl}`
         return `"${completion}"`
       })
       .join('\n')

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -96,7 +96,7 @@ _oclif-example()
 
   local commands="
 autocomplete --skip-instructions
-autocomplete:foo --bar --baz --json
+autocomplete:foo --bar --baz --dangerous --json
 "
 
   if [[ "\${COMP_CWORD}" -eq 1 ]] ; then
@@ -126,7 +126,7 @@ _oclif-example () {
   ## public cli commands & flags
   local -a _all_commands=(
 "autocomplete:display autocomplete instructions"
-"autocomplete\\:foo:cmd for autocomplete testing"
+"autocomplete\\:foo:cmd for autocomplete testing 'with some potentially dangerous script'"
   )
 
   _set_flags () {
@@ -141,6 +141,7 @@ autocomplete:foo)
   _command_flags=(
     "--bar=-[bar for testing]:"
 "--baz=-[baz for testing]:"
+"--dangerous=-['with some potentially dangerous script']:"
 "--json[output in json format]"
   )
 ;;

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -126,7 +126,7 @@ _oclif-example () {
   ## public cli commands & flags
   local -a _all_commands=(
 "autocomplete:display autocomplete instructions"
-"autocomplete\\:foo:cmd for autocomplete testing 'with some potentially dangerous script'"
+"autocomplete\\:foo:cmd for autocomplete testing \\\\\\\`with some potentially dangerous script\\\\\\\`"
   )
 
   _set_flags () {
@@ -141,7 +141,7 @@ autocomplete:foo)
   _command_flags=(
     "--bar=-[bar for testing]:"
 "--baz=-[baz for testing]:"
-"--dangerous=-['with some potentially dangerous script']:"
+"--dangerous=-[\\\\\\\`with some potentially dangerous script\\\\\\\`]:"
 "--json[output in json format]"
   )
 ;;

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -30,7 +30,7 @@
     },
     "autocomplete:foo": {
       "id": "autocomplete:foo",
-      "description": "cmd for autocomplete testing\nwith a multi-line description",
+      "description": "cmd for autocomplete testing `with some potentially dangerous script`\nwith a multi-line description",
       "pluginName": "@oclif/plugin-autocomplete",
       "pluginType": "core",
       "aliases": [],
@@ -44,6 +44,11 @@
           "name": "baz",
           "type": "option",
           "description": "baz for testing"
+        },
+        "dangerous": {
+          "name": "dangerous",
+          "type": "boolean",
+          "description": "`with some potentially dangerous script`"
         },
         "json": {
           "name": "json",

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -47,7 +47,7 @@
         },
         "dangerous": {
           "name": "dangerous",
-          "type": "boolean",
+          "type": "option",
           "description": "`with some potentially dangerous script`"
         },
         "json": {


### PR DESCRIPTION
- POTENTIAL SECURITY BREACH: any backtick in command description will be executed by ZSH
 every time the autocomplete is kicked,
 triggering potentially malicious script added there by bad guys