### PR TITLE
fix: fixing completion for "after topic command" / subcommands

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -206,7 +206,7 @@ fi
 
 _${cliBin}()
 {
-
+  COMP_WORDBREAKS=\${COMP_WORDBREAKS//:}
   local cur="\${COMP_WORDS[COMP_CWORD]}" opts IFS=$' \\t\\n'
   COMPREPLY=()
 


### PR DESCRIPTION
Autocompletion works on first level thanks to `__ltrim_colon_completions`
function that trims the autocompletion engine and return the right most part
of it.
However, on the input side, the issue persists for any topic completion
as stated in #9.

The fix is to locally remove the colon to be processed like a completion word
separator.