### PR TITLE
fix: sanitize double-quotes in description of commands/flags

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -16,7 +16,7 @@ function sanitizeDescription(description?: string): string {
     return ''
   }
   return description
-    .replace(/(`)/g, '\\\\\\$1') // backticks require triple-backslashes
+    .replace(/([`"])/g, '\\\\\\$1') // backticks and double-quotes require triple-backslashes
     .replace(/([\[\]])/g, '\\\\$1') // square brackets require double-backslashes
 }
 

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -96,7 +96,7 @@ _oclif-example()
 
   local commands="
 autocomplete --skip-instructions
-autocomplete:foo --bar --baz --dangerous --brackets --json
+autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --json
 "
 
   if [[ "\${COMP_CWORD}" -eq 1 ]] ; then
@@ -126,7 +126,7 @@ _oclif-example () {
   ## public cli commands & flags
   local -a _all_commands=(
 "autocomplete:display autocomplete instructions"
-"autocomplete\\:foo:cmd for autocomplete testing \\\\\\\`with some potentially dangerous script\\\\\\\` and \\\\\[square brackets\\\\\]"
+"autocomplete\\:foo:cmd for autocomplete testing \\\\\\\`with some potentially dangerous script\\\\\\\` and \\\\\[square brackets\\\\\] and \\\\\\\"double-quotes\\\\\\\""
   )
 
   _set_flags () {
@@ -143,6 +143,7 @@ autocomplete:foo)
 "--baz=-[baz for testing]:"
 "--dangerous=-[\\\\\\\`with some potentially dangerous script\\\\\\\`]:"
 "--brackets=-[\\\\\[square brackets\\\\\]]:"
+"--double-quotes=-[\\\\\\\"double-quotes\\\\\\\"]:"
 "--json[output in json format]"
   )
 ;;

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -30,7 +30,7 @@
     },
     "autocomplete:foo": {
       "id": "autocomplete:foo",
-      "description": "cmd for autocomplete testing `with some potentially dangerous script` and [square brackets]\nand a multi-line description",
+      "description": "cmd for autocomplete testing `with some potentially dangerous script` and [square brackets] and \"double-quotes\"\nand a multi-line description",
       "pluginName": "@oclif/plugin-autocomplete",
       "pluginType": "core",
       "aliases": [],
@@ -54,6 +54,11 @@
           "name": "brackets",
           "type": "option",
           "description": "[square brackets]"
+        },
+        "double-quotes": {
+          "name": "double-quotes",
+          "type": "option",
+          "description": "\"double-quotes\""
         },
         "json": {
           "name": "json",


### PR DESCRIPTION
Fixes #27 