### PR TITLE
fix: only use the first line of command/flag descriptions for zsh

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -18,6 +18,7 @@ function sanitizeDescription(description?: string): string {
   return description
     .replace(/(`)/g, '\\\\\\$1') // backticks require triple-backslashes
     .replace(/([\[\]])/g, '\\\\$1') // square brackets require double-backslashes
+    .split('\n')[0] // only use the first line
 }
 
 export default class Create extends AutocompleteBase {
@@ -141,7 +142,7 @@ compinit;\n`
 
     private get genAllCommandsMetaString(): string {
       return this.commands.map(c => {
-        return `\"${c.id.replace(/:/g, '\\:')}:${c.description.split('\n')[0]}\"`
+        return `\"${c.id.replace(/:/g, '\\:')}:${c.description}\"`
       }).join('\n')
     }
 

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -96,7 +96,7 @@ _oclif-example()
 
   local commands="
 autocomplete --skip-instructions
-autocomplete:foo --bar --baz --dangerous --brackets --json
+autocomplete:foo --bar --baz --dangerous --brackets --multi-line --json
 "
 
   if [[ "\${COMP_CWORD}" -eq 1 ]] ; then
@@ -143,6 +143,7 @@ autocomplete:foo)
 "--baz=-[baz for testing]:"
 "--dangerous=-[\\\\\\\`with some potentially dangerous script\\\\\\\`]:"
 "--brackets=-[\\\\\[square brackets\\\\\]]:"
+"--multi-line=-[multi-]:"
 "--json[output in json format]"
   )
 ;;

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -55,6 +55,11 @@
           "type": "option",
           "description": "[square brackets]"
         },
+        "multi-line": {
+          "name": "multi-line",
+          "type": "option",
+          "description": "multi-\nline"
+        },
         "json": {
           "name": "json",
           "type": "boolean",


### PR DESCRIPTION
Fixes #10 