### PR TITLE
fix(zsh): update zsh autocomplete to work with default settings

### DIFF
--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -40,7 +40,7 @@ export default class Index extends AutocompleteBase {
 ${chalk.bold(`Setup Instructions for ${bin.toUpperCase()} CLI Autocomplete ---`)}
 
 1) Add the autocomplete env var to your ${shell} profile and source it
-${chalk.cyan(`$ printf "$(${bin} autocomplete:script ${shell})" >> ~/.${shell}rc; source ~/.${shell}rc`)}
+${chalk.cyan(`$ printf "eval $(${bin} autocomplete:script ${shell})" >> ~/.${shell}rc; source ~/.${shell}rc`)}
 
 NOTE: ${note}
 

--- a/src/commands/autocomplete/script.ts
+++ b/src/commands/autocomplete/script.ts
@@ -20,11 +20,15 @@ export default class Script extends AutocompleteBase {
       `${this.prefix}${binUpcase}_AC_${shellUpcase}_SETUP_PATH=${path.join(
         this.autocompleteCacheDir,
         `${shell}_setup`,
-      )} && test -f $${binUpcase}_AC_${shellUpcase}_SETUP_PATH && source $${binUpcase}_AC_${shellUpcase}_SETUP_PATH;`,
+      )} && test -f $${binUpcase}_AC_${shellUpcase}_SETUP_PATH && source $${binUpcase}_AC_${shellUpcase}_SETUP_PATH;${this.suffix}`,
     )
   }
 
   private get prefix(): string {
-    return `\n# ${this.cliBin} autocomplete setup\n`
+    return '\n'
+  }
+
+  private get suffix(): string {
+    return ` # ${this.cliBin} autocomplete setup\n`
   }
 }

--- a/test/commands/autocomplete/index.test.ts
+++ b/test/commands/autocomplete/index.test.ts
@@ -13,7 +13,7 @@ skipWindows('autocomplete index', () => {
 Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---
 
 1) Add the autocomplete env var to your bash profile and source it
-$ printf \"$(oclif-example autocomplete:script bash)\" >> ~/.bashrc; source ~/.bashrc
+$ printf \"eval $(oclif-example autocomplete:script bash)\" >> ~/.bashrc; source ~/.bashrc
 
 NOTE: If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.
 
@@ -35,7 +35,7 @@ Enjoy!
 Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---
 
 1) Add the autocomplete env var to your zsh profile and source it
-$ printf \"$(oclif-example autocomplete:script zsh)\" >> ~/.zshrc; source ~/.zshrc
+$ printf \"eval $(oclif-example autocomplete:script zsh)\" >> ~/.zshrc; source ~/.zshrc
 
 NOTE: After sourcing, you can run \`$ compaudit -D\` to ensure no permissions conflicts are present
 

--- a/test/commands/autocomplete/script.test.ts
+++ b/test/commands/autocomplete/script.test.ts
@@ -9,10 +9,9 @@ skipWindows('autocomplete:script', () => {
   .command(['autocomplete:script', 'bash'])
   .it('outputs bash profile config', ctx => {
     expect(ctx.stdout).to.contain(`
-# oclif-example autocomplete setup
 OCLIF_EXAMPLE_AC_BASH_SETUP_PATH=${
   ctx.config.cacheDir
-}/autocomplete/bash_setup && test -f $OCLIF_EXAMPLE_AC_BASH_SETUP_PATH && source $OCLIF_EXAMPLE_AC_BASH_SETUP_PATH;
+}/autocomplete/bash_setup && test -f $OCLIF_EXAMPLE_AC_BASH_SETUP_PATH && source $OCLIF_EXAMPLE_AC_BASH_SETUP_PATH; # oclif-example autocomplete setup
 `,
     )
   })
@@ -22,10 +21,9 @@ OCLIF_EXAMPLE_AC_BASH_SETUP_PATH=${
   .command(['autocomplete:script', 'zsh'])
   .it('outputs zsh profile config', ctx => {
     expect(ctx.stdout).to.contain(`
-# oclif-example autocomplete setup
 OCLIF_EXAMPLE_AC_ZSH_SETUP_PATH=${
   ctx.config.cacheDir
-}/autocomplete/zsh_setup && test -f $OCLIF_EXAMPLE_AC_ZSH_SETUP_PATH && source $OCLIF_EXAMPLE_AC_ZSH_SETUP_PATH;
+}/autocomplete/zsh_setup && test -f $OCLIF_EXAMPLE_AC_ZSH_SETUP_PATH && source $OCLIF_EXAMPLE_AC_ZSH_SETUP_PATH; # oclif-example autocomplete setup
 `,
     )
   })


### PR DESCRIPTION
Closes #91

I tried to minimize my changes:
- I moved the `# test-multi autocomplete setup` comment from the beginning of the `autocomplete:script` output to the end, which no longer produces the error with default macOS zsh settings.  
- I changed `$(test-multi autocomplete:script zsh)` to `eval $(test-multi autocomplete:script zsh)`, which now works as expected with default zsh settings. (And the additional `eval` also has no effect/continues to work in bash, so I didn't bother making it conditional for zsh. Feel free to do that if it feels cleaner.)