### PR TITLE
feat: zsh autocomplete includes char prop from flag 

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -133,12 +133,15 @@ compinit;\n`
     return Object.keys(Klass.flags || {})
     .filter(flag => Klass.flags && !Klass.flags[flag].hidden)
     .map(flag => {
-      const f = (Klass.flags && Klass.flags[flag]) || {description: ''}
-      const isBoolean = f.type === 'boolean'
+      const {description = '', char, type} = Klass.flags[flag] || {}
+      const isBoolean = type === 'boolean'
       const name = isBoolean ? flag : `${flag}=-`
       const valueCmpl = isBoolean ? '' : ':'
-      const completion = `--${name}[${sanitizeDescription(f.description)}]${valueCmpl}`
-      return `"${completion}"`
+      const completionDesc = `[${sanitizeDescription(description)}]${valueCmpl}`
+
+      const completion = `"--${name}${completionDesc}"`
+      const charCompletion = char ? `"-${char}${completionDesc}"` : ''
+      return [completion, charCompletion].filter(Boolean).join('\n')
     })
     .join('\n')
   }

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -118,6 +118,7 @@ _oclif-example () {
 autocomplete)
   _command_flags=(
     "--skip-instructions[don't show installation instructions]"
+"-s[don't show installation instructions]"
   )
 ;;
 


### PR DESCRIPTION
e.g
`--refresh-cache  -r  -- Refresh cache (ignores displaying instructions)`
instead of
`--refresh-cache -- Refresh cache (ignores displaying instructions)`

Closes #217 