### PR TITLE
feat: add support for commands separated by spaces

### DIFF
--- a/src/autocomplete/bash-spaces.ts
+++ b/src/autocomplete/bash-spaces.ts
@@ -77,4 +77,4 @@ _<CLI_BIN>_autocomplete()
 complete -F _<CLI_BIN>_autocomplete <CLI_BIN>
 `
 
-export default script;
+export default script

--- a/src/autocomplete/bash.ts
+++ b/src/autocomplete/bash.ts
@@ -1,0 +1,36 @@
+const script = `#!/usr/bin/env bash
+
+_<CLI_BIN>_autocomplete()
+{
+
+  local cur="\${COMP_WORDS[COMP_CWORD]}" opts IFS=$' \\t\\n'
+  COMPREPLY=()
+
+  local commands="
+<BASH_COMMANDS_WITH_FLAGS_LIST>
+"
+
+  if [[ "$cur" != "-"* ]]; then
+    opts=$(printf "$commands" | grep -Eo '^[a-zA-Z0-9:_-]+')
+  else
+    local __COMP_WORDS
+    if [[ \${COMP_WORDS[2]} == ":" ]]; then
+      #subcommand
+      __COMP_WORDS=$(printf "%s" "\${COMP_WORDS[@]:1:3}")
+    else
+      #simple command
+      __COMP_WORDS="\${COMP_WORDS[@]:1:1}"
+    fi
+    opts=$(printf "$commands" | grep "\${__COMP_WORDS}" | sed -n "s/^\${__COMP_WORDS} //p")
+  fi
+  _get_comp_words_by_ref -n : cur
+  COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
+  __ltrim_colon_completions "$cur"
+  return 0
+
+}
+
+complete -o default -F _<CLI_BIN>_autocomplete $<CLI_BIN>
+`
+
+export default script;

--- a/src/autocomplete/bash.ts
+++ b/src/autocomplete/bash.ts
@@ -30,7 +30,7 @@ _<CLI_BIN>_autocomplete()
 
 }
 
-complete -o default -F _<CLI_BIN>_autocomplete $<CLI_BIN>
+complete -o default -F _<CLI_BIN>_autocomplete <CLI_BIN>
 `
 
-export default script;
+export default script

--- a/src/autocomplete/bash_spaces.ts
+++ b/src/autocomplete/bash_spaces.ts
@@ -1,0 +1,80 @@
+const script = `#!/usr/bin/env bash
+
+# This function joins an array using a character passed in
+# e.g. ARRAY=(one two three) -> join_by ":" \${ARRAY[@]} -> "one:two:three"
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+_<CLI_BIN>_autocomplete()
+{
+
+  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \\t\\n'
+  COMPREPLY=()
+
+  local commands="
+<BASH_COMMANDS_WITH_FLAGS_LIST>
+"
+
+  function __trim_colon_commands()
+  {
+    # Turn $commands into an array
+    commands=("\${commands[@]}")
+
+    if [[ -z "$colonPrefix" ]]; then
+      colonPrefix="$normalizedCommand:"
+    fi
+
+    # Remove colon-word prefix from $commands
+    commands=( "\${commands[@]/$colonPrefix}" )
+
+    for i in "\${!commands[@]}"; do
+      if [[ "\${commands[$i]}" == "$normalizedCommand" ]]; then
+        # If the currently typed in command is a topic command we need to remove it to avoid suggesting it again
+        unset "\${commands[$i]}"
+      else
+        # Trim subcommands from each command
+        commands[$i]="\${commands[$i]%%:*}"
+      fi
+    done
+  }
+
+  if [[ "$cur" != "-"* ]]; then
+    # Command
+    __COMP_WORDS=( "\${COMP_WORDS[@]:1}" )
+
+    # The command typed by the user but separated by colons (e.g. "mycli command subcom" -> "command:subcom")
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${__COMP_WORDS[@]}")" )"
+
+    # The command hirarchy, with colons, leading up to the last subcommand entered (e.g. "mycli com subcommand subsubcom" -> "com:subcommand:")
+    colonPrefix="\${normalizedCommand%"\${normalizedCommand##*:}"}"
+
+    if [[ -z "$normalizedCommand" ]]; then
+      # If there is no normalizedCommand yet the user hasn't typed in a full command
+      # So we should trim all subcommands & flags from $commands so we can suggest all top level commands
+      opts=$(printf "%s " "\${commands[@]}" | grep -Eo '^[a-zA-Z0-9_-]+')
+    else
+      # Filter $commands to just the ones that match the $normalizedCommand and turn into an array
+      commands=( $(compgen -W "$commands" -- "\${normalizedCommand}") )
+      # Trim higher level and subcommands from the subcommands to suggest
+      __trim_colon_commands "$colonPrefix"
+
+      opts=$(printf "%s " "\${commands[@]}") # | grep -Eo '^[a-zA-Z0-9_-]+'
+    fi
+  else 
+    # Flag
+
+    # The full CLI command separated by colons (e.g. "mycli command subcommand --fl" -> "command:subcommand")
+    # This needs to be defined with $COMP_CWORD-1 as opposed to above because the current "word" on the command line is a flag and the command is everything before the flag
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${COMP_WORDS[@]:1:($COMP_CWORD - 1)}")" )"
+
+    # The line below finds the command in $commands using grep
+    # Then, using sed, it removes everything from the found command before the --flags (e.g. "command:subcommand:subsubcom --flag1 --flag2" -> "--flag1 --flag2")
+    opts=$(printf "%s " "\${commands[@]}" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
+  fi
+
+  COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))
+}
+
+complete -F _<CLI_BIN>_autocomplete <CLI_BIN>
+`
+
+export default script;

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -109,12 +109,10 @@ compinit;\n`
 
     plugins.forEach(p => {
       p.commands.forEach(c => {
-        console.log(c)
         try {
           if (c.hidden) return
           cmds.push({
             id: c.id,
-            // id: c.id.replace(':', this.config.topicSeparator),
             description: sanitizeDescription(c.description || ''),
             flags: c.flags,
           })

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -267,6 +267,7 @@ complete -F _${cliBin} ${cliBin}
 `
     } else {
       bashScript = `#!/usr/bin/env bash
+
 _${cliBin}()
 {
 

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -196,7 +196,7 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 _${cliBin}()
 {
 
-  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \t\n'
+  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \\t\\n'
   COMPREPLY=()
 
   local commands="

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -266,7 +266,7 @@ ${this.bashCommandsWithFlagsList}
   COMPREPLY=($(compgen -W "$opts" -- \${cur}))
 }
 
-_${cliBin} ${cliBin}
+complete -F _${cliBin} ${cliBin}
 
 `
     } else {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -239,7 +239,7 @@ ${this.bashCommandsWithFlagsList}
     if [[ -z "$normalizedCommand" ]]; then
       # If there is no normalizedCommand yet the user hasn't typed in a full command
       # So we should trim all subcommands & flags from $commands so we can suggest all top level commands
-      opts=$(echo "$commands" | grep -Eo '^[a-zA-Z0-9_-]+')
+      opts=$(printf "%s " "\${commands[@]}" | grep -Eo '^[a-zA-Z0-9_-]+')
     else
       # Filter $commands to just the ones that match the $normalizedCommand and turn into an array
       commands=( $(compgen -W "$commands" -- "\${normalizedCommand}") )
@@ -257,7 +257,7 @@ ${this.bashCommandsWithFlagsList}
 
     # The line below finds the command in $commands using grep
     # Then, using sed, it removes everything from the found command before the --flags (e.g. "command:subcommand:subsubcom --flag1 --flag2" -> "--flag1 --flag2")
-    opts=$(echo "$commands" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
+    opts=$(printf "%s " "\${commands[@]}" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
   fi
 
   COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -215,10 +215,10 @@ ${this.bashCommandsWithFlagsList}
     # Remove colon-word prefix from $commands
     commands=( "\${commands[@]/$colonPrefix}" )
 
-    for i in \${!commands[@]}; do
+    for i in "\${!commands[@]}"; do
       if [[ "\${commands[$i]}" == "$normalizedCommand" ]]; then
         # If the currently typed in command is a topic command we need to remove it to avoid suggesting it again
-        unset commands[$i]
+        unset "\${commands[$i]}"
       else
         # Trim subcommands from each command
         commands[$i]="\${commands[$i]%%:*}"
@@ -231,10 +231,10 @@ ${this.bashCommandsWithFlagsList}
     __COMP_WORDS=( "\${COMP_WORDS[@]:1}" )
 
     # The command typed by the user but separated by colons (e.g. "mycli command subcom" -> "command:subcom")
-    normalizedCommand="$( printf "%s" "$(join_by ":" \${__COMP_WORDS[@]})" )"
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${__COMP_WORDS[@]}")" )"
 
     # The command hirarchy, with colons, leading up to the last subcommand entered (e.g. "mycli com subcommand subsubcom" -> "com:subcommand:")
-    colonPrefix="\${normalizedCommand%\${normalizedCommand##*:}}"
+    colonPrefix="\${normalizedCommand%"\${normalizedCommand##*:}"}"
 
     if [[ -z "$normalizedCommand" ]]; then
       # If there is no normalizedCommand yet the user hasn't typed in a full command
@@ -243,7 +243,6 @@ ${this.bashCommandsWithFlagsList}
     else
       # Filter $commands to just the ones that match the $normalizedCommand and turn into an array
       commands=( $(compgen -W "$commands" -- "\${normalizedCommand}") )
-
       # Trim higher level and subcommands from the subcommands to suggest
       __trim_colon_commands "$colonPrefix"
 
@@ -253,19 +252,18 @@ ${this.bashCommandsWithFlagsList}
     # Flag
 
     # The full CLI command separated by colons (e.g. "mycli command subcommand --fl" -> "command:subcommand")
-    # This needs to be defined with $COMP_CWORD-1 as opposed to above because the current character on the command line is "-" and we want everything before that
-    normalizedCommand="$( printf "%s" "$(join_by ":" \${COMP_WORDS[@]:1:($COMP_CWORD - 1)})" )"
+    # This needs to be defined with $COMP_CWORD-1 as opposed to above because the current "word" on the command line is a flag and the command is everything before the flag
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${COMP_WORDS[@]:1:($COMP_CWORD - 1)}")" )"
 
     # The line below finds the command in $commands using grep
     # Then, using sed, it removes everything from the found command before the --flags (e.g. "command:subcommand:subsubcom --flag1 --flag2" -> "--flag1 --flag2")
-    opts=$(printf "$commands" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
+    opts=$(echo "$commands" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
   fi
 
-  COMPREPLY=($(compgen -W "$opts" -- \${cur}))
+  COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))
 }
 
 complete -F _${cliBin} ${cliBin}
-
 `
     } else {
       bashScript = `#!/usr/bin/env bash

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -1,9 +1,12 @@
-import * as fs from 'fs-extra'
 import * as path from 'path'
 
-const debug = require('debug')('autocomplete:create')
+import * as fs from 'fs-extra'
 
+import bashAutocomplete from '../../autocomplete/bash'
+import bashAutocompleteWithSpaces from '../../autocomplete/bash_spaces'
 import {AutocompleteBase} from '../../base'
+
+const debug = require('debug')('autocomplete:create')
 
 type CommandCompletion = {
   id: string;
@@ -184,125 +187,8 @@ compinit;\n`
 
   private get bashCompletionFunction(): string {
     const cliBin = this.cliBin
-    let bashScript = ''
-
-    if (this.config.topicSeparator === ' ') {
-      bashScript = `#!/usr/bin/env bash
-
-# This function joins an array using a character passed in
-# e.g. ARRAY=(one two three) -> join_by ":" \${ARRAY[@]} -> "one:two:three"
-function join_by { local IFS="$1"; shift; echo "$*"; }
-
-_${cliBin}()
-{
-
-  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \\t\\n'
-  COMPREPLY=()
-
-  local commands="
-${this.bashCommandsWithFlagsList}
-"
-
-  function __trim_colon_commands()
-  {
-    # Turn $commands into an array
-    commands=("\${commands[@]}")
-
-    if [[ -z "$colonPrefix" ]]; then
-      colonPrefix="$normalizedCommand:"
-    fi
-
-    # Remove colon-word prefix from $commands
-    commands=( "\${commands[@]/$colonPrefix}" )
-
-    for i in "\${!commands[@]}"; do
-      if [[ "\${commands[$i]}" == "$normalizedCommand" ]]; then
-        # If the currently typed in command is a topic command we need to remove it to avoid suggesting it again
-        unset "\${commands[$i]}"
-      else
-        # Trim subcommands from each command
-        commands[$i]="\${commands[$i]%%:*}"
-      fi
-    done
-  }
-
-  if [[ "$cur" != "-"* ]]; then
-    # Command
-    __COMP_WORDS=( "\${COMP_WORDS[@]:1}" )
-
-    # The command typed by the user but separated by colons (e.g. "mycli command subcom" -> "command:subcom")
-    normalizedCommand="$( printf "%s" "$(join_by ":" "\${__COMP_WORDS[@]}")" )"
-
-    # The command hirarchy, with colons, leading up to the last subcommand entered (e.g. "mycli com subcommand subsubcom" -> "com:subcommand:")
-    colonPrefix="\${normalizedCommand%"\${normalizedCommand##*:}"}"
-
-    if [[ -z "$normalizedCommand" ]]; then
-      # If there is no normalizedCommand yet the user hasn't typed in a full command
-      # So we should trim all subcommands & flags from $commands so we can suggest all top level commands
-      opts=$(printf "%s " "\${commands[@]}" | grep -Eo '^[a-zA-Z0-9_-]+')
-    else
-      # Filter $commands to just the ones that match the $normalizedCommand and turn into an array
-      commands=( $(compgen -W "$commands" -- "\${normalizedCommand}") )
-      # Trim higher level and subcommands from the subcommands to suggest
-      __trim_colon_commands "$colonPrefix"
-
-      opts=$(printf "%s " "\${commands[@]}") # | grep -Eo '^[a-zA-Z0-9_-]+'
-    fi
-  else 
-    # Flag
-
-    # The full CLI command separated by colons (e.g. "mycli command subcommand --fl" -> "command:subcommand")
-    # This needs to be defined with $COMP_CWORD-1 as opposed to above because the current "word" on the command line is a flag and the command is everything before the flag
-    normalizedCommand="$( printf "%s" "$(join_by ":" "\${COMP_WORDS[@]:1:($COMP_CWORD - 1)}")" )"
-
-    # The line below finds the command in $commands using grep
-    # Then, using sed, it removes everything from the found command before the --flags (e.g. "command:subcommand:subsubcom --flag1 --flag2" -> "--flag1 --flag2")
-    opts=$(printf "%s " "\${commands[@]}" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
-  fi
-
-  COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))
-}
-
-complete -F _${cliBin} ${cliBin}
-`
-    } else {
-      bashScript = `#!/usr/bin/env bash
-
-_${cliBin}()
-{
-
-  local cur="\${COMP_WORDS[COMP_CWORD]}" opts IFS=$' \\t\\n'
-  COMPREPLY=()
-
-  local commands="
-${this.bashCommandsWithFlagsList}
-"
-
-  if [[ "$cur" != "-"* ]]; then
-    opts=$(printf "$commands" | grep -Eo '^[a-zA-Z0-9:_-]+')
-  else
-    local __COMP_WORDS
-    if [[ \${COMP_WORDS[2]} == ":" ]]; then
-      #subcommand
-      __COMP_WORDS=$(printf "%s" "\${COMP_WORDS[@]:1:3}")
-    else
-      #simple command
-      __COMP_WORDS="\${COMP_WORDS[@]:1:1}"
-    fi
-    opts=$(printf "$commands" | grep "\${__COMP_WORDS}" | sed -n "s/^\${__COMP_WORDS} //p")
-  fi
-  _get_comp_words_by_ref -n : cur
-  COMPREPLY=( $(compgen -W "\${opts}" -- \${cur}) )
-  __ltrim_colon_completions "$cur"
-  return 0
-
-}
-
-complete -o default -F _${cliBin} ${cliBin}
-`
-    }
-
-    return bashScript
+    let bashScript = this.config.topicSeparator === ' ' ? bashAutocompleteWithSpaces : bashAutocomplete
+    return bashScript.replace(/<CLI_BIN>/g, cliBin).replace(/<BASH_COMMANDS_WITH_FLAGS_LIST>/g, this.bashCommandsWithFlagsList)
   }
 
   private get zshCompletionFunction(): string {

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as fs from 'fs-extra'
 
 import bashAutocomplete from '../../autocomplete/bash'
-import bashAutocompleteWithSpaces from '../../autocomplete/bash_spaces'
+import bashAutocompleteWithSpaces from '../../autocomplete/bash-spaces'
 import {AutocompleteBase} from '../../base'
 
 const debug = require('debug')('autocomplete:create')
@@ -187,7 +187,7 @@ compinit;\n`
 
   private get bashCompletionFunction(): string {
     const cliBin = this.cliBin
-    let bashScript = this.config.topicSeparator === ' ' ? bashAutocompleteWithSpaces : bashAutocomplete
+    const bashScript = this.config.topicSeparator === ' ' ? bashAutocompleteWithSpaces : bashAutocomplete
     return bashScript.replace(/<CLI_BIN>/g, cliBin).replace(/<BASH_COMMANDS_WITH_FLAGS_LIST>/g, this.bashCommandsWithFlagsList)
   }
 

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -87,6 +87,100 @@ autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line
 complete -o default -F _oclif-example oclif-example\n`)
     })
 
+    it('#bashCompletionFunction with spaces', async () => {
+      const spacedConfig = new Config({root})
+
+      await spacedConfig.load()
+      spacedConfig.topicSeparator = ' '
+      // : any is required for the next two lines otherwise ts will complain about _manifest and bashCompletionFunction being private down below
+      const spacedCmd: any = new Create([], spacedConfig)
+      const spacedPlugin: any = new Plugin({root})
+      spacedCmd.config.plugins = [spacedPlugin]
+      spacedPlugin._manifest = () => {
+        return loadJSON(path.resolve(__dirname, '../../test.oclif.manifest.json'))
+      }
+      await spacedPlugin.load()
+
+      expect(spacedCmd.bashCompletionFunction).to.eq(`#!/usr/bin/env bash
+
+# This function joins an array using a character passed in
+# e.g. ARRAY=(one two three) -> join_by ":" \${ARRAY[@]} -> "one:two:three"
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+_oclif-example()
+{
+
+  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \t\n'
+  COMPREPLY=()
+
+  local commands="
+autocomplete --skip-instructions
+autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line --json
+"
+
+  function __trim_colon_commands()
+  {
+    # Turn $commands into an array
+    commands=("\${commands[@]}")
+
+    if [[ -z "$colonPrefix" ]]; then
+      colonPrefix="$normalizedCommand:"
+    fi
+
+    # Remove colon-word prefix from $commands
+    commands=( "\${commands[@]/$colonPrefix}" )
+
+    for i in "\${!commands[@]}"; do
+      if [[ "\${commands[$i]}" == "$normalizedCommand" ]]; then
+        # If the currently typed in command is a topic command we need to remove it to avoid suggesting it again
+        unset "\${commands[$i]}"
+      else
+        # Trim subcommands from each command
+        commands[$i]="\${commands[$i]%%:*}"
+      fi
+    done
+  }
+
+  if [[ "$cur" != "-"* ]]; then
+    # Command
+    __COMP_WORDS=( "\${COMP_WORDS[@]:1}" )
+
+    # The command typed by the user but separated by colons (e.g. "mycli command subcom" -> "command:subcom")
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${__COMP_WORDS[@]}")" )"
+
+    # The command hirarchy, with colons, leading up to the last subcommand entered (e.g. "mycli com subcommand subsubcom" -> "com:subcommand:")
+    colonPrefix="\${normalizedCommand%"\${normalizedCommand##*:}"}"
+
+    if [[ -z "$normalizedCommand" ]]; then
+      # If there is no normalizedCommand yet the user hasn't typed in a full command
+      # So we should trim all subcommands & flags from $commands so we can suggest all top level commands
+      opts=$(printf "%s " "\${commands[@]}" | grep -Eo '^[a-zA-Z0-9_-]+')
+    else
+      # Filter $commands to just the ones that match the $normalizedCommand and turn into an array
+      commands=( $(compgen -W "$commands" -- "\${normalizedCommand}") )
+      # Trim higher level and subcommands from the subcommands to suggest
+      __trim_colon_commands "$colonPrefix"
+
+      opts=$(printf "%s " "\${commands[@]}") # | grep -Eo '^[a-zA-Z0-9_-]+'
+    fi
+  else 
+    # Flag
+
+    # The full CLI command separated by colons (e.g. "mycli command subcommand --fl" -> "command:subcommand")
+    # This needs to be defined with $COMP_CWORD-1 as opposed to above because the current "word" on the command line is a flag and the command is everything before the flag
+    normalizedCommand="$( printf "%s" "$(join_by ":" "\${COMP_WORDS[@]:1:($COMP_CWORD - 1)}")" )"
+
+    # The line below finds the command in $commands using grep
+    # Then, using sed, it removes everything from the found command before the --flags (e.g. "command:subcommand:subsubcom --flag1 --flag2" -> "--flag1 --flag2")
+    opts=$(printf "%s " "\${commands[@]}" | grep "\${normalizedCommand}" | sed -n "s/^\${normalizedCommand} //p")
+  fi
+
+  COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))
+}
+
+complete -F _oclif-example oclif-example\n`)
+    })
+
     it('#zshCompletionFunction', () => {
       /* eslint-disable no-useless-escape */
       expect(cmd.zshCompletionFunction).to.eq(`#compdef oclif-example

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -53,7 +53,7 @@ compinit;
     it('#bashCompletionFunction', () => {
       expect(cmd.bashCompletionFunction).to.eq(`#!/usr/bin/env bash
 
-_oclif-example()
+_oclif-example_autocomplete()
 {
 
   local cur="\${COMP_WORDS[COMP_CWORD]}" opts IFS=$' \\t\\n'
@@ -84,7 +84,7 @@ autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line
 
 }
 
-complete -o default -F _oclif-example oclif-example\n`)
+complete -o default -F _oclif-example_autocomplete oclif-example\n`)
     })
 
     it('#bashCompletionFunction with spaces', async () => {
@@ -107,7 +107,7 @@ complete -o default -F _oclif-example oclif-example\n`)
 # e.g. ARRAY=(one two three) -> join_by ":" \${ARRAY[@]} -> "one:two:three"
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
-_oclif-example()
+_oclif-example_autocomplete()
 {
 
   local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \\t\\n'
@@ -178,7 +178,7 @@ autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line
   COMPREPLY=($(compgen -W "$opts" -- "\${cur}"))
 }
 
-complete -F _oclif-example oclif-example\n`)
+complete -F _oclif-example_autocomplete oclif-example\n`)
     })
 
     it('#zshCompletionFunction', () => {

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -110,7 +110,7 @@ function join_by { local IFS="$1"; shift; echo "$*"; }
 _oclif-example()
 {
 
-  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \t\n'
+  local cur="\${COMP_WORDS[COMP_CWORD]}" opts normalizedCommand colonPrefix IFS=$' \\t\\n'
   COMPREPLY=()
 
   local commands="

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
       "./src"
     ],
     "strict": true,
-    "target": "es2017"
+    "target": "es2019",
+    "types": [
+      "mocha"
+    ]
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
## Description
This allows CLI's that use spaces as their `topicSeparator` to use autocomplete on bash.
It should work on all versions of bash without any external dependencies.

## Testing Instructions
1. Clone the example CLI: https://github.com/oclif/hello-world
    1. Link it globally using `npm link`.
1. Pull this branch.
    1. Run `yarn install` and `yarn build` on it.
1. Run `oex plugins link .` at this repo's root.
1. Run `oex autocomplete` anywhere and follow the resulting instructions.
### Expected results
You should now be able to use autocomplete with `oex`.
```
$ oex <tab><tab>
autocomplete  hello  help  plugins

$ oex h<tab>
$ oex hel<tab><tab>
hello  help

$ oex p<tab>
$ oex plugins

$ oex plugins install --<tab><tab>
--force    --help     --verbose
```

You should also find the autocomplete script at `~/Library/Caches/oclif-hello-world/autocomplete/functions/bash/oex.bash` and you'll see all the commands for the CLI listed at the top. 

