### PR TITLE
Don't use `moment` for formatting date objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "chalk": "^4.1.0",
     "cli-ux": "^5.6.6",
     "debug": "^4.0.0",
-    "fs-extra": "^9.0.1",
-    "moment": "^2.22.1"
+    "fs-extra": "^9.0.1"
   },
   "devDependencies": {
     "@oclif/plugin-help": "^5",

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,5 @@
 import {Command} from '@oclif/core'
 import * as fs from 'fs-extra'
-import * as moment from 'moment'
 import * as path from 'path'
 
 export abstract class AutocompleteBase extends Command {
@@ -47,7 +46,7 @@ export abstract class AutocompleteBase extends Command {
   }
 
   writeLogFile(msg: string) {
-    const entry = `[${moment().format()}] ${msg}\n`
+    const entry = `[${(new Date()).toLocaleString()}] ${msg}\n`
     const fd = fs.openSync(this.acLogfilePath, 'a')
     fs.write(fd, entry)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,7 +3647,7 @@ mock-stdin@^1.0.0:
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
   integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
 
-moment@^2.15.1, moment@^2.22.1, moment@^2.24.0:
+moment@^2.15.1, moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
I'd like to use this plugin in https://github.com/expo/eas-cli but we try to minimize the installation size of our CLI. `moment` weighs around 3.3 MB and it doesn't bring too much functionality to the plugin. It's only used for formatting log timestamps. Logs don't seem relevant to the plugin.

It could be easily replaced with the built-in Date functions.

<img width="218" alt="Screenshot 2021-12-20 at 16 38 23" src="https://user-images.githubusercontent.com/5256730/146793404-b61b80cf-69ac-4eff-99cf-3c1736eaa266.png">

