### PR TITLE
feat: aliases support

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -114,10 +114,19 @@ compinit;\n`
       p.commands.forEach(c => {
         try {
           if (c.hidden) return
+          const description = sanitizeDescription(c.description || '')
+          const flags = c.flags
           cmds.push({
             id: c.id,
-            description: sanitizeDescription(c.description || ''),
-            flags: c.flags,
+            description,
+            flags,
+          })
+          c.aliases.forEach(a => {
+            cmds.push({
+              id: a,
+              description,
+              flags,
+            })
           })
         } catch (error: any) {
           debug(`Error creating zsh flag spec for command ${c.id}`)

--- a/test/commands/autocomplete/create.test.ts
+++ b/test/commands/autocomplete/create.test.ts
@@ -62,6 +62,7 @@ _oclif-example_autocomplete()
   local commands="
 autocomplete --skip-instructions
 autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line --json
+foo --bar --baz --dangerous --brackets --double-quotes --multi-line --json
 "
 
   if [[ "$cur" != "-"* ]]; then
@@ -116,6 +117,7 @@ _oclif-example_autocomplete()
   local commands="
 autocomplete --skip-instructions
 autocomplete:foo --bar --baz --dangerous --brackets --double-quotes --multi-line --json
+foo --bar --baz --dangerous --brackets --double-quotes --multi-line --json
 "
 
   function __trim_colon_commands()
@@ -194,6 +196,7 @@ _oclif-example () {
   local -a _all_commands=(
 "autocomplete:display autocomplete instructions"
 "autocomplete\\:foo:cmd for autocomplete testing \\\\\\\`with some potentially dangerous script\\\\\\\` and \\\\\[square brackets\\\\\] and \\\\\\\"double-quotes\\\\\\\""
+"foo:cmd for autocomplete testing \\\\\\\`with some potentially dangerous script\\\\\\\` and \\\\\[square brackets\\\\\] and \\\\\\\"double-quotes\\\\\\\""
   )
 
   _set_flags () {
@@ -205,6 +208,18 @@ autocomplete)
 ;;
 
 autocomplete:foo)
+  _command_flags=(
+    "--bar=-[bar for testing]:"
+"--baz=-[baz for testing]:"
+"--dangerous=-[\\\\\\\`with some potentially dangerous script\\\\\\\`]:"
+"--brackets=-[\\\\\[square brackets\\\\\]]:"
+"--double-quotes=-[\\\\\\\"double-quotes\\\\\\\"]:"
+"--multi-line=-[multi-]:"
+"--json[output in json format]"
+  )
+;;
+
+foo)
   _command_flags=(
     "--bar=-[bar for testing]:"
 "--baz=-[baz for testing]:"

--- a/test/test.oclif.manifest.json
+++ b/test/test.oclif.manifest.json
@@ -33,7 +33,7 @@
       "description": "cmd for autocomplete testing `with some potentially dangerous script` and [square brackets] and \"double-quotes\"\nand a multi-line description",
       "pluginName": "@oclif/plugin-autocomplete",
       "pluginType": "core",
-      "aliases": [],
+      "aliases": ["foo"],
       "flags": {
         "bar": {
           "name": "bar",


### PR DESCRIPTION
Hi team! Thanks for the great plugin!
I need the approval of this PR 🙏🏽 

If a command with a topic has an alias the autocomplete doesn't show it 

```
some-cli/
   src/
      commands/
         some-topic/
            my-awesome-command
```

```
class MyAwesomeCommand extends Command {
    static alias = ['my-awesome-command']
    ...
}
```

Previous behavior:
`some-cli TAB TAB  => some-topic`

Actual behavior:
`some-cli TAB TAB  => some-topic and my-awesome-command`


Thanks a lot!