### PR TITLE
ci: prerelease from beta

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    uses: oclif/github-workflows/.github/workflows/githubRelease.yml@prereleases-semver
+    uses: oclif/github-workflows/.github/workflows/githubRelease.yml@main
     secrets: inherit
     with:
       prerelease: ${{ github.ref_name != 'main' }}

--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -3,13 +3,18 @@ name: version, tag and github release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - prerelease/*
+    tags-ignore:
+      - "*"
 
 jobs:
   release:
-    uses: oclif/github-workflows/.github/workflows/githubRelease.yml@main
+    uses: oclif/github-workflows/.github/workflows/githubRelease.yml@prereleases-semver
     secrets: inherit
-
+    with:
+      prerelease: ${{ github.ref_name != 'main' }}
   # most repos won't use this
   # depends on previous job to avoid git collisions, not for any functionality reason
   # docs:

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -2,7 +2,7 @@ name: publish
 
 on:
   release:
-    types: [released]
+    types: [published]
   # support manual release in case something goes wrong and needs to be repeated or tested
   workflow_dispatch:
     inputs:
@@ -10,10 +10,23 @@ on:
         description: tag that needs to publish
         type: string
         required: true
+
 jobs:
+  getDistTag:
+    outputs:
+      tag: ${{ steps.distTag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag  }}
+      - uses: oclif/github-workflows/.github/actions/getPreReleaseTag@prereleases-semver
+        id: distTag
+
   npm:
     uses: oclif/github-workflows/.github/workflows/npmPublish.yml@main
+    needs: [getDistTag]
     with:
-      tag: latest
+      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag  }}
-      - uses: oclif/github-workflows/.github/actions/getPreReleaseTag@prereleases-semver
+      - uses: oclif/github-workflows/.github/actions/getPreReleaseTag@main
         id: distTag
 
   npm:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-autocomplete",
   "description": "autocomplete plugin for oclif",
-  "version": "1.3.1",
+  "version": "1.4.0-beta.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-autocomplete/issues",
   "dependencies": {


### PR DESCRIPTION
### notes: 
1. uses a branch of the oclif/github-workflows.  Once that merges, this code should be pointed back to main of the oclif/github-workflows
1. the `beta` branch is now renamed `prerelease/beta`

merging this should *not* produce a prerelease (only commit is `ci:`

merging a feat/fix to the prerelease/beta branch should.  The intention is for `re/powershell` to merge and test this out.

@W-11791541@
@W-11791492@
@W-11890429@