### PR TITLE
fix: render ejs templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@oclif/plugin-help": "^5",
     "@oclif/test": "^2",
     "@types/chai": "^4",
+    "@types/ejs": "^3.1.2",
     "@types/fs-extra": "^9.0.13",
     "@types/mocha": "^8",
     "@types/nock": "^11.1.0",

--- a/src/autocomplete/zsh.ts
+++ b/src/autocomplete/zsh.ts
@@ -1,16 +1,6 @@
 import * as util from 'util'
 import {Config, Interfaces, Command} from '@oclif/core'
-
-function sanitizeSummary(description?: string): string {
-  if (description === undefined) {
-    return ''
-  }
-  return description
-  .replace(/([`"])/g, '\\\\\\$1') // backticks and double-quotes require triple-backslashes
-  // eslint-disable-next-line no-useless-escape
-  .replace(/([\[\]])/g, '\\\\$1') // square brackets require double-backslashes
-  .split('\n')[0] // only use the first line
-}
+import * as ejs from 'ejs'
 
 const argTemplate = '        "%s")\n          %s\n        ;;\n'
 
@@ -42,6 +32,17 @@ export default class ZshCompWithSpaces {
     this.config = config
     this.topics = this.getTopics()
     this.commands = this.getCommands()
+  }
+
+  private sanitizeSummary(summary?: string): string {
+    if (summary === undefined) {
+      return ''
+    }
+    return ejs.render(summary, {config: this.config})
+    .replace(/([`"])/g, '\\\\\\$1') // backticks and double-quotes require triple-backslashes
+    // eslint-disable-next-line no-useless-escape
+    .replace(/([\[\]])/g, '\\\\$1') // square brackets require double-backslashes
+    .split('\n')[0] // only use the first line
   }
 
   public generate(): string {
@@ -133,7 +134,7 @@ _${this.config.bin}
       // skip hidden flags
       if (f.hidden) continue
 
-      const flagSummary = sanitizeSummary(f.summary || f.description)
+      const flagSummary = this.sanitizeSummary(f.summary || f.description)
 
       let flagSpec = ''
 
@@ -369,7 +370,7 @@ _${this.config.bin}
       return 0
     })
     .map(t => {
-      const description = t.description ? sanitizeSummary(t.description) : `${t.name.replace(/:/g, ' ')} commands`
+      const description = t.description ? this.sanitizeSummary(t.description) : `${t.name.replace(/:/g, ' ')} commands`
 
       return {
         name: t.name,
@@ -386,7 +387,7 @@ _${this.config.bin}
     this.config.plugins.forEach(p => {
       p.commands.forEach(c => {
         if (c.hidden) return
-        const summary = sanitizeSummary(c.summary || c.description)
+        const summary = this.sanitizeSummary(c.summary || c.description)
         const flags = c.flags
         cmds.push({
           id: c.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -727,6 +727,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/ejs@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.2.tgz#75d277b030bc11b3be38c807e10071f45ebc78d9"
+  integrity sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"


### PR DESCRIPTION
Render ejs templates in cmd/flag summaries.

![Screenshot 2023-06-26 at 14 38 12](https://github.com/oclif/plugin-autocomplete/assets/6853656/7a880250-fae7-40d3-b51b-e3ba122d8666)

QA suggestions:
1) checkout pr
2) link plugin-autocomplete
3) refresh completion cache: `sf autocomplete --refresh-cache`
4) reload terminal
5) `help` and `update` should have `sf` or `sfdx` in their summary.