### PR TITLE
fix: block pwsh completion if CLI uses colon sep

### DIFF
--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -1,4 +1,5 @@
 import {Args, ux, Flags} from '@oclif/core'
+import {EOL} from 'os'
 import * as chalk from 'chalk'
 
 import {AutocompleteBase} from '../../base'
@@ -31,6 +32,10 @@ export default class Index extends AutocompleteBase {
   async run() {
     const {args, flags} = await this.parse(Index)
     const shell = args.shell || this.determineShell(this.config.shell)
+
+    if (shell === 'powershell' && this.config?.topicSeparator === ':') {
+      this.error(`PowerShell completion is not supported in CLIs using colon as the topic separator.${EOL}See: https://oclif.io/docs/topic_separator`)
+    }
 
     ux.action.start(`${chalk.bold('Building the autocomplete cache')}`)
     await Create.run([], this.config)


### PR DESCRIPTION
Updates `autocomplete` command to throw if trying to generate completion files to powershell in a CLI that doesn't support spaces as separators.


either `topicSeparator: ":"` or not having `topicSeparator` in the pjson means the CLI only supports colon as the topic separator.

![Screenshot 2023-08-01 at 11 46 53](https://github.com/oclif/plugin-autocomplete/assets/6853656/01c6f394-fc3e-4356-ad6e-aad84c3cd7ed)
![Screenshot 2023-08-01 at 11 47 15](https://github.com/oclif/plugin-autocomplete/assets/6853656/f4ba43d7-0a7c-47a8-a0c0-d4dd77ba84b3)
