### PR TITLE
fix: update help text

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -29,6 +29,10 @@ export abstract class AutocompleteBase extends Command {
     }
   }
 
+  public getSetupEnvVar(shell: string): string {
+    return `${this.cliBinEnvVar}_AC_${shell.toUpperCase()}_SETUP_PATH`
+  }
+
   writeLogFile(msg: string) {
     mkdirSync(this.config.cacheDir, {recursive: true})
     const entry = `[${new Date().toISOString()}] ${msg}\n`

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -48,8 +48,7 @@ export default class Index extends AutocompleteBase {
   }
 
   private printShellInstructions(shell: string): void {
-    const binUpcase = this.cliBinEnvVar
-    const shellUpcase = shell.toUpperCase()
+    const setupEnvVar = `${this.cliBinEnvVar}_AC_${shell.toUpperCase()}_SETUP_PATH`
     const tabStr = shell === 'bash' ? '<TAB><TAB>' : '<TAB>'
     const scriptCommand = `${this.config.bin} autocomplete${this.config.topicSeparator}script ${shell}`
 
@@ -65,7 +64,7 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
   ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.bashrc; source ~/.bashrc`)}
 
-  The previous command adds the ${chalk.cyan(`${binUpcase}_AC_${shellUpcase}_SETUP_PATH`)} environment variable to your Bash config file and then sources the file.
+  The previous command adds the ${chalk.cyan(setupEnvVar)} environment variable to your Bash config file and then sources the file.
 
   NOTE: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
 
@@ -89,7 +88,7 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
   ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.zshrc; source ~/.zshrc`)}
 
-  The previous command adds the ${chalk.cyan(`${binUpcase}_AC_${shellUpcase}_SETUP_PATH`)} environment variable to your zsh config file and then sources the file.
+  The previous command adds the ${chalk.cyan(setupEnvVar)} environment variable to your zsh config file and then sources the file.
 
 2) (Optional) Run this command to ensure that you have no permissions conflicts:
 
@@ -126,7 +125,8 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
     instructions += `
   Every time you enter ${tabStr}, the autocomplete feature displays a list of commands (or flags if you type --), along with their summaries. Enter a letter and then ${tabStr} again to narrow down the list until you end up with the complete command that you want to execute.
 
-  Enjoy!`
+  Enjoy!
+`
     this.log(instructions)
   }
 }

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -60,44 +60,44 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
     switch (shell) {
       case 'bash': {
         instructions += `
-1) Run this command (starting with "printf") in your terminal window:
+1) Run this command in your terminal window:
 
-  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.bashrc; source ~/.bashrc`)}
+  ${chalk.cyan(`printf "eval $(${scriptCommand})" >> ~/.bashrc; source ~/.bashrc`)}
 
   The previous command adds the ${chalk.cyan(setupEnvVar)} environment variable to your Bash config file and then sources the file.
 
   ${chalk.bold('NOTE')}: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
 
-  ${chalk.cyan(`$ printf "eval $(${scriptCommand}) >> ~/.bash_profile; source ~/.bash_profile`)}
+  ${chalk.cyan(`printf "eval $(${scriptCommand}) >> ~/.bash_profile; source ~/.bash_profile`)}
   
   Or:
 
-  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.profile; source ~/.profile`)}
+  ${chalk.cyan(`printf "eval $(${scriptCommand})" >> ~/.profile; source ~/.profile`)}
 
 2) Start using autocomplete:
 
-  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
   `
         break
       }
 
       case 'zsh': {
         instructions += `
-1) Run this command (starting with "printf") in your terminal window:
+1) Run this command in your terminal window:
 
-  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.zshrc; source ~/.zshrc`)}
+  ${chalk.cyan(`printf "eval $(${scriptCommand})" >> ~/.zshrc; source ~/.zshrc`)}
 
   The previous command adds the ${chalk.cyan(setupEnvVar)} environment variable to your zsh config file and then sources the file.
 
 2) (Optional) Run this command to ensure that you have no permissions conflicts:
 
-  ${chalk.cyan('$ compaudit -D')}
+  ${chalk.cyan('compaudit -D')}
 
 3) Start using autocomplete:
 
-  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
   `
         break
       }
@@ -115,8 +115,8 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
 3) Start using autocomplete:
 
-  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
   `
         break
       }

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -66,7 +66,7 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
   The previous command adds the ${chalk.cyan(setupEnvVar)} environment variable to your Bash config file and then sources the file.
 
-  NOTE: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
+  ${chalk.bold('NOTE')}: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
 
   ${chalk.cyan(`$ printf "eval $(${scriptCommand}) >> ~/.bash_profile; source ~/.bash_profile`)}
   

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -5,30 +5,6 @@ import {EOL} from 'node:os'
 import {AutocompleteBase} from '../../base.js'
 import Create from './create.js'
 
-const noteFromShell = (shell: string) => {
-  switch (shell) {
-    case 'zsh': {
-      return `After sourcing, you can run \`${chalk.cyan(
-        '$ compaudit -D',
-      )}\` to ensure no permissions conflicts are present`
-    }
-
-    case 'bash': {
-      return 'If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.'
-    }
-
-    case 'powershell': {
-      return `Use the \`MenuComplete\` mode to get matching completions printed below the command line:\n${chalk.cyan(
-        'Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete',
-      )}`
-    }
-
-    default: {
-      return ''
-    }
-  }
-}
-
 export default class Index extends AutocompleteBase {
   static args = {
     shell: Args.string({
@@ -67,32 +43,90 @@ export default class Index extends AutocompleteBase {
     ux.action.stop()
 
     if (!flags['refresh-cache']) {
-      const {bin} = this.config
-      const tabStr = shell === 'bash' ? '<TAB><TAB>' : '<TAB>'
-
-      const instructions =
-        shell === 'powershell'
-          ? `New-Item -Type Directory -Path (Split-Path -Parent $PROFILE) -ErrorAction SilentlyContinue
-Add-Content -Path $PROFILE -Value (Invoke-Expression -Command "${bin} autocomplete${this.config.topicSeparator}script ${shell}"); .$PROFILE`
-          : `$ printf "eval $(${bin} autocomplete${this.config.topicSeparator}script ${shell})" >> ~/.${shell}rc; source ~/.${shell}rc`
-
-      const note = noteFromShell(shell)
-
-      this.log(`
-${chalk.bold(`Setup Instructions for ${bin.toUpperCase()} CLI Autocomplete ---`)}
-
-1) Add the autocomplete ${shell === 'powershell' ? 'file' : 'env var'} to your ${shell} profile and source it
-
-${chalk.cyan(instructions)}
-
-${chalk.bold('NOTE')}: ${note}
-
-2) Test it out, e.g.:
-${chalk.cyan(`$ ${bin} ${tabStr}`)}                 # Command completion
-${chalk.cyan(`$ ${bin} command --${tabStr}`)}       # Flag completion
-
-Enjoy!
-`)
+      this.printShellInstructions(shell)
     }
+  }
+
+  private printShellInstructions(shell: string): void {
+    const binUpcase = this.cliBinEnvVar
+    const shellUpcase = shell.toUpperCase()
+    const tabStr = shell === 'bash' ? '<TAB><TAB>' : '<TAB>'
+    const scriptCommand = `${this.config.bin} autocomplete${this.config.topicSeparator}script ${shell}`
+
+    let instructions = `
+Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
+==============================================
+`
+
+    switch (shell) {
+      case 'bash': {
+        instructions += `
+1) Run this command (starting with "printf") in your terminal window:
+
+  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.bashrc; source ~/.bashrc`)}
+
+  The previous command adds the ${chalk.cyan(`${binUpcase}_AC_${shellUpcase}_SETUP_PATH`)} environment variable to your Bash config file and then sources the file.
+
+  NOTE: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
+
+  ${chalk.cyan(`$ printf "eval $(${scriptCommand}) >> ~/.bash_profile; source ~/.bash_profile`)}
+  
+  Or:
+
+  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.profile; source ~/.profile`)}
+
+2) Start using autocomplete:
+
+  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  `
+        break
+      }
+
+      case 'zsh': {
+        instructions += `
+1) Run this command (starting with "printf") in your terminal window:
+
+  ${chalk.cyan(`$ printf "eval $(${scriptCommand})" >> ~/.zshrc; source ~/.zshrc`)}
+
+  The previous command adds the ${chalk.cyan(`${binUpcase}_AC_${shellUpcase}_SETUP_PATH`)} environment variable to your zsh config file and then sources the file.
+
+2) (Optional) Run this command to ensure that you have no permissions conflicts:
+
+  ${chalk.cyan('$ compaudit -D')}
+
+3) Start using autocomplete:
+
+  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  `
+        break
+      }
+
+      case 'powershell': {
+        instructions += `
+1) Run these two cmdlets in your PowerShell window in the order shown:
+
+  ${chalk.cyan(`New-Item -Type Directory -Path (Split-Path -Parent $PROFILE) -ErrorAction SilentlyContinue
+  Add-Content -Path $PROFILE -Value (Invoke-Expression -Command "${scriptCommand}"); .$PROFILE`)}
+
+2) (Optional) If you want matching completions printed below the command line, run this cmdlet:
+
+  ${chalk.cyan('Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete')}
+
+3) Start using autocomplete:
+
+  ${chalk.cyan(`$ sf ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`$ sf command --${tabStr}`)}        # Flag completion
+  `
+        break
+      }
+    }
+
+    instructions += `
+  Every time you enter ${tabStr}, the autocomplete feature displays a list of commands (or flags if you type --), along with their summaries. Enter a letter and then ${tabStr} again to narrow down the list until you end up with the complete command that you want to execute.
+
+  Enjoy!`
+    this.log(instructions)
   }
 }

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -48,7 +48,7 @@ export default class Index extends AutocompleteBase {
   }
 
   private printShellInstructions(shell: string): void {
-    const setupEnvVar = `${this.cliBinEnvVar}_AC_${shell.toUpperCase()}_SETUP_PATH`
+    const setupEnvVar = this.getSetupEnvVar(shell)
     const tabStr = shell === 'bash' ? '<TAB><TAB>' : '<TAB>'
     const scriptCommand = `${this.config.bin} autocomplete${this.config.topicSeparator}script ${shell}`
 

--- a/src/commands/autocomplete/script.ts
+++ b/src/commands/autocomplete/script.ts
@@ -20,8 +20,6 @@ export default class Script extends AutocompleteBase {
     const {args} = await this.parse(Script)
     const shell = args.shell ?? this.config.shell
 
-    const binUpcase = this.cliBinEnvVar
-    const shellUpcase = shell.toUpperCase()
     if (shell === 'powershell') {
       const completionFuncPath = path.join(
         this.config.cacheDir,
@@ -33,12 +31,10 @@ export default class Script extends AutocompleteBase {
       this.log(`. ${completionFuncPath}`)
     } else {
       this.log(
-        `${this.prefix}${binUpcase}_AC_${shellUpcase}_SETUP_PATH=${path.join(
+        `${this.prefix}${this.getSetupEnvVar(shell)}=${path.join(
           this.autocompleteCacheDir,
           `${shell}_setup`,
-        )} && test -f $${binUpcase}_AC_${shellUpcase}_SETUP_PATH && source $${binUpcase}_AC_${shellUpcase}_SETUP_PATH;${
-          this.suffix
-        }`,
+        )} && test -f $${this.getSetupEnvVar(shell)} && source $${this.getSetupEnvVar(shell)};${this.suffix}`,
       )
     }
   }

--- a/test/commands/autocomplete/index.test.ts
+++ b/test/commands/autocomplete/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-useless-escape */
 import {expect, test} from '@oclif/test'
 
 // autocomplete will throw error on windows ci
@@ -9,43 +8,13 @@ skipWindows('autocomplete index', () => {
     .stdout()
     .command(['autocomplete', 'bash'])
     .it('provides bash instructions', (ctx) => {
-      expect(ctx.stdout).to.contain(`
-Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---
-
-1) Add the autocomplete env var to your bash profile and source it
-
-$ printf \"eval $(oclif-example autocomplete:script bash)\" >> ~/.bashrc; source ~/.bashrc
-
-NOTE: If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.
-
-2) Test it out, e.g.:
-$ oclif-example <TAB><TAB>                 # Command completion
-$ oclif-example command --<TAB><TAB>       # Flag completion
-
-Enjoy!
-
-`)
+      expect(ctx.stdout).to.contain(`Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---`)
     })
 
   test
     .stdout()
     .command(['autocomplete', 'zsh'])
     .it('provides zsh instructions', (ctx) => {
-      expect(ctx.stdout).to.contain(`
-Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---
-
-1) Add the autocomplete env var to your zsh profile and source it
-
-$ printf \"eval $(oclif-example autocomplete:script zsh)\" >> ~/.zshrc; source ~/.zshrc
-
-NOTE: After sourcing, you can run \`$ compaudit -D\` to ensure no permissions conflicts are present
-
-2) Test it out, e.g.:
-$ oclif-example <TAB>                 # Command completion
-$ oclif-example command --<TAB>       # Flag completion
-
-Enjoy!
-
-`)
+      expect(ctx.stdout).to.contain(`Setup Instructions for OCLIF-EXAMPLE CLI Autocomplete ---`)
     })
 })


### PR DESCRIPTION
This PR updates `autocomplete` cmd help text with improvements made by @jshackell-sfdc.
No functional changes.

`bash`
![Screenshot 2024-01-30 at 17 27 17](https://github.com/oclif/plugin-autocomplete/assets/6853656/cc6c2abd-50b7-4679-aa5e-46201460e318)

`zsh`
![Screenshot 2024-01-30 at 17 29 49](https://github.com/oclif/plugin-autocomplete/assets/6853656/2efffc3e-861b-452d-bf46-3810e99225c2)

`powershell`
![Screenshot 2024-01-30 at 17 28 11](https://github.com/oclif/plugin-autocomplete/assets/6853656/e5798eff-b643-47e8-b95f-ed3b4badb9ba)

@W-14810430@