### PR TITLE
fix: output correct CLI binary name in 'autocomplete' command

### DIFF
--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -76,8 +76,8 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
 2) Start using autocomplete:
 
-  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`${this.config.bin} ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`${this.config.bin} command --${tabStr}`)}        # Flag completion
   `
         break
       }
@@ -96,8 +96,8 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
 3) Start using autocomplete:
 
-  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`${this.config.bin} ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`${this.config.bin} command --${tabStr}`)}        # Flag completion
   `
         break
       }
@@ -115,8 +115,8 @@ Setup Instructions for ${this.config.bin.toUpperCase()} CLI Autocomplete ---
 
 3) Start using autocomplete:
 
-  ${chalk.cyan(`sf ${tabStr}`)}                  # Command completion
-  ${chalk.cyan(`sf command --${tabStr}`)}        # Flag completion
+  ${chalk.cyan(`${this.config.bin} ${tabStr}`)}                  # Command completion
+  ${chalk.cyan(`${this.config.bin} command --${tabStr}`)}        # Flag completion
   `
         break
       }


### PR DESCRIPTION
This PR fixes a bug where the "sf" command is hardcoded in the instructions given by "your-cli autocomplete". A minor one for sure, I'm just starting exploring the plugin for an internal use case at my company.

Thanks for all the work on this!