### PR TITLE
feat: add `refresh-cache` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,11 @@
     "devPlugins": [
       "@oclif/plugin-help"
     ],
-    "flexibleTaxonomy": true
+    "flexibleTaxonomy": true,
+    "hooks": {
+      "plugins:postinstall": "./lib/hooks/refresh-cache.js",
+      "plugins:postuninstall": "./lib/hooks/refresh-cache.js"
+    }
   },
   "repository": "oclif/plugin-autocomplete",
   "scripts": {

--- a/src/hooks/refresh-cache.ts
+++ b/src/hooks/refresh-cache.ts
@@ -1,0 +1,8 @@
+import {Hook} from '@oclif/core'
+
+const hook: Hook<'refresh'> = async function (opts) {
+  // this `config` instance already have installed/uninstalled plugins loaded
+  await opts.config.runCommand('autocomplete:create')
+}
+
+export default hook


### PR DESCRIPTION
**DEPENDS ON**: https://github.com/oclif/plugin-plugins/pull/932

This PR adds a new `refresh-cache` hook that runs `autocomplete create` to regenerate autocomplete functions after installing or uninstalling plugins.

### QA

1. checkout this PR and `sf plugins link` it
2. checkout this PR: https://github.com/oclif/plugin-plugins/pull/932  and `sf plugins link` it
3. enable completion: `sf autocomplete` and follow instructions
4. type `sf org a<TAB>`, see it doesn't suggest `org api` 
5. install new plugin: `sf plugins install @cristiand391/sf-plugin-api`
6. open a new terminal pane (for zsh to source completion again) and repeat step 4, it should suggest `org api` options
7. uninstall plugin: `sf plugins uninstall @cristiand391/sf-plugin-api`
8. repeat step 6, shouldn't see `org api` completion.

@W-12465784@
